### PR TITLE
Kernal's sleep method sleeps forever if not params are passed to it.  Se...

### DIFF
--- a/bin/mrd
+++ b/bin/mrd
@@ -314,7 +314,7 @@ class App
   end 
 
   def wait_forever
-    Kernel.sleep 1_000_000
+    Kernel.sleep
   end
 end
 


### PR DESCRIPTION
...e: http://apidock.com/ruby/Kernel/sleep
