### PR TITLE
Fixed mysql has gone away error by disabling innodb_file_per_table option.

### DIFF
--- a/bin/mrd
+++ b/bin/mrd
@@ -134,7 +134,7 @@ class App
           socket = #{socket}
           thread_concurrency = 4
           innodb_data_file_path = ibdata1:10M:autoextend
-          innodb_file_per_table
+          innodb_file_per_table = OFF
           ft_min_word_len = 3
         }.gsub(/^\s+/,'')
         if @log


### PR DESCRIPTION
This changes the default to disable innodb_file_per_table option because by default on OSX there is a limit of 256 open files per process, which breaks tests for larger projects that use awesome mrd gem.

The detailed description of this problem is here: https://github.com/mezis/mrd/issues/8

@mezis Already agreed to accept this pull request in the corresponding issue - thank you! I'm not sure about bumping the version of the gem.
